### PR TITLE
Gmail API で メール送信 と zip ファイル生成処理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,15 @@
 venv/
+.pytest_cache
+__pycache__/
 
 # log file
 log/
-
-.pytest_cache
-__pycache__/
 
 # extension
 *.csv
 *.txt
 *.xlsx
 *.zip
+
+# token directory
+*/token/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ log/
 
 # token directory
 */token/
+
+# envriments
+.env
+

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ log/
 *.zip
 
 # token directory
-*/token/
+token/
 
 # envriments
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ log/
 
 .pytest_cache
 __pycache__/
+
+# extension
+*.csv
+*.txt
+*.xlsx
+*.zip

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 ## About
 Python 動きみたいときとか使う
+
+## 構成
+`src/` 配下
+
+| Directory | 内容 |
+|:--:|:--:|
+|conf_logger|ログ処理試してみる|
+|gmail_api|Gmail API を使ってみる|
+|np|numpy 試す|
+|logging|ログ処理試す|
+|pytest_prj|-|
+|uuid|uuid 生成|
+|zip_try|zip 化|

--- a/src/gmail_api/README.md
+++ b/src/gmail_api/README.md
@@ -1,0 +1,27 @@
+## Gmail API
+
+## 前提
+- Gmail API で プロジェクト作成し、OAuth 2.0 クライアントの JSONファイルを用意
+
+## 実行環境
+- Python 3.9.1
+- Mac M1
+
+## 操作
+
+1. 必要なファイル・環境変数を準備
+  ```bash
+  # .token/credentials.json
+  > OAuth 2.0 クライアントの JSONファイル
+  
+  # .env
+  SENDER_ADDRESS=<送信者メールアドレス>
+  TO_ADDRESS=<送信先メールアドレス>
+  ```
+2. `gmail_api.py` を実行する
+
+3. メール送信されたか確認する
+
+
+## 参考
+- 

--- a/src/gmail_api/const.py
+++ b/src/gmail_api/const.py
@@ -1,0 +1,10 @@
+import os
+from os.path import join, dirname
+from dotenv import load_dotenv
+
+load_dotenv()
+dotenv_path = join(dirname(__file__), '.env')
+load_dotenv(dotenv_path)
+
+SENDER_ADDRESS = os.environ.get("SENDER_ADDRESS")
+TO_ADDRESS = os.environ.get("TO_ADDRESS")

--- a/src/gmail_api/gmail_api.py
+++ b/src/gmail_api/gmail_api.py
@@ -1,11 +1,12 @@
+import base64
 import pickle
 import os.path
+
+from apiclient import errors
+from email.mime.text import MIMEText
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
-import base64
-from email.mime.text import MIMEText
-from apiclient import errors
 
 import const
 
@@ -13,6 +14,12 @@ import const
 class GmailApi(object):
 
     def __init__(self, sender, to):
+        """ gmail operations with the Gmail API
+
+        :param
+          sender(str): Sender Address
+          to(str): To Address
+        """
         self.scope = ['https://www.googleapis.com/auth/gmail.send']
         self.sender = sender
         self.to = to

--- a/src/gmail_api/gmail_api.py
+++ b/src/gmail_api/gmail_api.py
@@ -1,0 +1,74 @@
+import pickle
+import os.path
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+import base64
+from email.mime.text import MIMEText
+from apiclient import errors
+
+import const
+
+
+class GmailApi(object):
+
+    def __init__(self, sender, to):
+        self.scope = ['https://www.googleapis.com/auth/gmail.send']
+        self.sender = sender
+        self.to = to
+        self.service = self.get_access_token()
+
+    def get_access_token(self):
+        """ アクセストークンの取得
+
+        :return:
+          service
+        """
+        creds = None
+        if os.path.exists('token/token.pickle'):
+            with open('token/token.pickle', 'rb') as token:
+                creds = pickle.load(token)
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    'token/credentials.json', self.scope)
+                creds = flow.run_local_server()
+            with open('token/token.pickle', 'wb') as token:
+                pickle.dump(creds, token)
+
+        return build('gmail', 'v1', credentials=creds)
+
+    def create_message(self, subject_, msg_text):
+        """ メール本文の作成 """
+
+        msg = MIMEText(msg_text)
+        msg['to'] = self.to
+        msg['from'] = self.sender
+        msg['subject'] = subject_
+        encode_message = base64.urlsafe_b64encode(msg.as_bytes())
+
+        return {'raw': encode_message.decode()}
+
+    def send_message(self, user_id, msg):
+        """ メール送信の実行 """
+        try:
+            msg = (self.service.users().messages().send(userId=user_id, body=msg)
+                   .execute())
+            print(f"Message Id: {msg['id']}")
+
+            return msg
+        except errors.HttpError as error:
+            print(f"An error occurred: {error}")
+
+
+if __name__ == '__main__':
+    gmail_api = GmailApi(sender=const.SENDER_ADDRESS, to=const.TO_ADDRESS)
+
+    # メール本文の作成
+    subject = 'メール送信自動化テスト_ Class Gmail API'
+    message_text = 'メール送信の自動化テストをしています。'
+    message = gmail_api.create_message(subject_=subject, msg_text=message_text)
+
+    gmail_api.send_message(user_id='me', msg=message)

--- a/src/zip_try/zip_ope.py
+++ b/src/zip_try/zip_ope.py
@@ -1,0 +1,29 @@
+import pathlib
+import pyzipper
+
+
+def mkdir(mkdir_path='./zip_storage'):
+    pathlib.Path(mkdir_path).mkdir(exist_ok=True)
+
+
+def touch_file(dir_='zip_storage', file_name='file', extension='txt'):
+    try:
+        with open(f"./{dir_}/{file_name}.{extension}", "x") as f:
+            f.write("x モードでファイルを作成しました。")
+    except FileExistsError:
+        print("ファイルが既に存在します。")
+
+
+def compress_zip(pass_word=b'password', dir_zip='zip_storage', file_name='file'):
+    with pyzipper.AESZipFile('archive_with_pass.zip', 'w',
+                             encryption=pyzipper.WZ_AES) as zf:
+        zf.setpassword(pass_word)
+
+        zf.write(f'./{dir_zip}/{file_name}.txt', arcname=f'{file_name}.txt')
+        zf.write(f'./{dir_zip}/{file_name}.xlsx', arcname=f'{file_name}.xlsx')
+
+
+if __name__ == '__main__':
+    mkdir()
+    touch_file(extension='csv')
+    compress_zip()


### PR DESCRIPTION
## Details
- Send Mail on Gmail API
- Implementation of zip file generation process
- `README.md` を追加

## Ref
- https://developers.google.com/docs/api/quickstart/python?hl=en
- https://valmore.work/automate-gmail-sending/
- https://github.com/googleapis/google-api-python-client/issues/563